### PR TITLE
`docker-compose.yml` 内にコメントアウトされている `platform` はない

### DIFF
--- a/5/introduce/build_local_env.md
+++ b/5/introduce/build_local_env.md
@@ -30,8 +30,6 @@ cp docker/docker-compose.yml.default docker/docker-compose.yml
 
 ※ このファイルは自由に編集可能です。
 
-M1チップをご利用の場合は、docker-compose.yml の中で、コメントアウトされている `platform` が３箇所ほどあるので、そのコメントアウトを全て解除します。 
-
 ### Docker を起動する
 docker ディレクトリに移動してから Docker 起動します。
 


### PR DESCRIPTION
`platform` というパラメータや記載は現在 `docker-compose.yml` にありません。

また、M1 macにて特に `docker-compose.yml` の修正を必要とせずDockerへのインストールやbaserCMSの動作は成功しています。