### PR TITLE
Update index.md

### DIFF
--- a/5/web_api/baser_api/index.md
+++ b/5/web_api/baser_api/index.md
@@ -34,7 +34,7 @@ baser API は認証は不要です。
 
 ### ブログコンテンツ
 - [ブログコンテンツの一覧の取得](bc-blog/blog_contents/index)
-- [ブログコンテンツ情報の取得](bc-blog/blog_contents/view)
+- [ブログコンテンツの単一取得](bc-blog/blog_contents/view)
 
 ### ブログ記事
 - [ブログ記事一覧の取得](bc-blog/blog_posts/index)


### PR DESCRIPTION
一覧表示では「ブログコンテンツ情報の取得」とあるが、詳細表示では「ブログコンテンツの単一取得」と記述されている

詳細表示の記述が内容的にも正しいと判断し、一覧表示側も「ブログコンテンツの単一取得」と修正した。